### PR TITLE
Add 'minify' option for all css/js/json output format transformers.

### DIFF
--- a/lib/shared.js
+++ b/lib/shared.js
@@ -14,11 +14,14 @@ Promise.prototype.nodeify = function (cb) {
   }
 }
 
+var minifiers = {};
+
 module.exports = Transformer;
 function Transformer(obj) {
   this.name = obj.name;
   this.engines = obj.engines;
   this.isBinary = obj.isBinary || false;
+  this.isMinifier = obj.isMinifier || false;
   this.outputFormat = obj.outputFormat;
   this._cache = {};
   if (typeof obj.async === 'function') {
@@ -30,6 +33,19 @@ function Transformer(obj) {
     this.sync = true;
   } else {
     this.sync = obj.sudoSync || false;
+  }
+
+  if (this.isMinifier)
+    minifiers[this.outputFormat] = this;
+  else {
+    var minifier = minifiers[this.outputFormat];
+    if (minifier) {
+      this.minify = function(str, options) {
+        if (options && options.minify)
+          return minifier.renderSync(str, typeof options.minify === 'object' && options.minify || {});
+        return str;
+      }
+    }
   }
 }
 
@@ -56,12 +72,15 @@ Transformer.prototype.loadModule = function () {
   }
   throw new Error('In order to apply the transform ' + this.name + ' you must install one of ' + this.engines.map(function (e) { return '"' + e + '"'; }).join());
 };
+Transformer.prototype.minify = function(str, options) {
+  return str;
+}
 Transformer.prototype.renderSync = function (str, options) {
   options = options || {};
   options = clone(options);
   this.loadModule();
   if (this._renderSync) {
-    return this._renderSync((this.isBinary ? str : fixString(str)), options);
+    return this.minify(this._renderSync((this.isBinary ? str : fixString(str)), options), options);
   } else if (this.sudoSync) {
     options.sudoSync = true;
     var res, err;
@@ -70,7 +89,7 @@ Transformer.prototype.renderSync = function (str, options) {
       else res = val;
     });
     if (err) throw err;
-    else if (res != undefined) return res;
+    else if (res != undefined) return this.minify(res, options);
     else if (typeof this.sudoSync === 'string') throw new Error(this.sudoSync.replace(/FILENAME/g, options.filename || ''));
     else throw new Error('There was a problem transforming ' + (options.filename || '') + ' syncronously using ' + this.name);
   } else {
@@ -85,7 +104,7 @@ Transformer.prototype.render = function (str, options, cb) {
     if (self._renderAsync) {
       self._renderAsync((self.isBinary ? str : fixString(str)), clone(options), function (err, val) {
         if (err) reject(err);
-        else resolve(val);
+        else resolve(self.minify(val, options));
       })
     } else {
       resolve(self.renderSync(str, options));

--- a/lib/transformers.js
+++ b/lib/transformers.js
@@ -2,6 +2,43 @@ var dirname = require('path').dirname;
 var Transformer = require('./shared');
 
 /**
+ * minifiers must be first in order to be incorporated inside instances of respective output formats
+ */
+
+exports.uglify = exports.uglifyJS = exports['uglify-js'] = new Transformer({
+  name: 'uglify-js',
+  engines: ['uglify-js'],
+  outputFormat: 'js',
+  isMinifier: true,
+  sync: function (str, options) {
+    options.fromString = true;
+    return this.cache(options) || this.cache(options, this.engine.minify(str, options).code);
+  }
+});
+
+exports.uglifyCSS = exports['uglify-css'] = new Transformer({
+  name: 'uglify-css',
+  engines: ['css'],
+  outputFormat: 'css',
+  isMinifier: true,
+  sync: function (str, options) {
+    options.compress = options.compress != false && options.beautify != true;
+    return this.cache(options) || this.cache(options, this.engine.stringify(this.engine.parse(str), options));
+  }
+});
+
+exports.uglifyJSON = exports['uglify-json'] = new Transformer({
+  name: 'uglify-json',
+  engines: ['.'],
+  outputFormat: 'json',
+  isMinifier: true,
+  sync: function (str, options) {
+    return JSON.stringify(JSON.parse(str), null, options.beautify);
+  }
+});
+
+
+/**
  * Syncronous Templating Languages
  */
 
@@ -381,39 +418,6 @@ exports.sass = new Transformer({
 });
 
 /**
- * minifiers
- */
-
-exports.uglify = exports.uglifyJS = exports['uglify-js'] = new Transformer({
-  name: 'uglify-js',
-  engines: ['uglify-js'],
-  outputFormat: 'js',
-  sync: function (str, options) {
-    options.fromString = true;
-    return this.cache(options) || this.cache(options, this.engine.minify(str, options).code);
-  }
-});
-
-exports.uglifyCSS = exports['uglify-css'] = new Transformer({
-  name: 'uglify-css',
-  engines: ['css'],
-  outputFormat: 'css',
-  sync: function (str, options) {
-    options.compress = options.compress != false && options.beautify != true;
-    return this.cache(options) || this.cache(options, this.engine.stringify(this.engine.parse(str), options));
-  }
-});
-
-exports.uglifyJSON = exports['uglify-json'] = new Transformer({
-  name: 'uglify-json',
-  engines: ['.'],
-  outputFormat: 'json',
-  sync: function (str, options) {
-    return JSON.stringify(JSON.parse(str), null, options.beautify);
-  }
-});
-
-/**
  * Miscelaneous
  */
 
@@ -567,3 +571,5 @@ exports.js = new Transformer({
     return this.cache(options) || this.cache(options, str);
   }
 });
+
+


### PR DESCRIPTION
coffee.renderSync(str, {minify:true})

This will invoke second pass through uglify-{js;css;json} transformer.
The value can be minifier specific options as well, ie:

coffee.renderSync(str, {minify:{unsafe:true}})

will enable unsafe compression in uglifyjs2.

Signed-off-by: Karel Tuma karel.tuma@gmail.com
