### PR TITLE
Adds the 'escape-html' transformer.

### DIFF
--- a/lib/transformers.js
+++ b/lib/transformers.js
@@ -524,6 +524,21 @@ exports.verbatim = new Transformer({
   }
 });
 
+exports["escape-html"] = new Transformer({
+  name: 'escape-html',
+  engines: ['.'],// `.` means "no dependency"
+  outputFormat: 'xml',
+  sync: function (str, options) {
+    var escaped = str.replace(/&/g, '&amp;')
+                     .replace(/</g, '&lt;')
+                     .replace(/>/g, '&gt;')
+                     .replace(/"/g, '&quot;')
+                     .replace(/'/g, '&#x27;');
+
+    return this.cache(options) || this.cache(options, escaped);
+  }
+});
+
 exports.component = exports['component-js'] = new Transformer({
   name: 'component-js',
   engines: ['component-builder'],

--- a/test/simple/escape-html/sample-a-expected.txt
+++ b/test/simple/escape-html/sample-a-expected.txt
@@ -1,0 +1,1 @@
+hello world

--- a/test/simple/escape-html/sample-a.txt
+++ b/test/simple/escape-html/sample-a.txt
@@ -1,0 +1,1 @@
+hello world

--- a/test/simple/escape-html/sample-b-expected.txt
+++ b/test/simple/escape-html/sample-b-expected.txt
@@ -1,0 +1,1 @@
+&lt;span class=&quot;foo&quot; id=&#x27;bar&#x27;&gt;goodbye world&lt;/span&gt;

--- a/test/simple/escape-html/sample-b.txt
+++ b/test/simple/escape-html/sample-b.txt
@@ -1,0 +1,1 @@
+<span class="foo" id='bar'>goodbye world</span>


### PR DESCRIPTION
It escapes the &, <, >, ", and ' characters into HTML entities so that all HTML in the passed string will be interpreted as plain text by the browser. This is useful for showing things like example HTML snippets of code or arbitrary user input (that you don't want to be interpreted as HTML).
